### PR TITLE
[Chore] Update dockerfile and docker usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cd ..
 git clone https://github.com/GAIR-NLP/daVinci-MagiHuman
 cd daVinci-MagiHuman
 pip install -r requirements.txt
-pip install --no-deps -r /app/requirements-nodeps.txt
+pip install --no-deps -r requirements-nodeps.txt
 
 # Optional (only for sr-1080p): Install MagiAttention
 git clone --recursive https://github.com/SandAI-org/MagiAttention.git


### PR DESCRIPTION
## Summary
- Add `Dockerfile.magi_human.base` for MagiHuman runtime image setup.
- Update Docker section in README to recommend using the prebuilt `sandai/magi-human:latest` image directly.
- Clarify that the 03/25 updated `sandai/magi-compiler:latest` image does not include `magi_attention`, so `sr_1080p` is not supported (other pipelines remain available).

Tested on base, sr-540 and sr1080

base: https://github.com/user-attachments/assets/1deebed1-d25c-4fce-bc09-684b6720c3a8
